### PR TITLE
feat: add database test config and bump spring boot version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.4</version>
+		<version>4.0.5</version>
 		<relativePath/>
 		<!-- lookup parent from repository -->
 	</parent>

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -5,7 +5,7 @@ spring:
     ansi:
       enabled: always
   datasource:
-    url: ${DB_URL:jdbc:postgresql://localhost:5001/postgres}
+    url: ${DB_URL:jdbc:postgresql://localhost:5001/critoria_db}
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
     driver-class-name: org.postgresql.Driver

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,3 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5001/critoria_test}


### PR DESCRIPTION
Decided to use the same database for integrated tests, with a different schema, but same flyway migrations. H2 showed compatibility problems to run close to Postgres behaviour. Test Containers setup for Postgres in Ubuntu works fine, but showed compatibility issues with Rancher on Windows 11.